### PR TITLE
Fix missing import

### DIFF
--- a/src/hci/socket.rs
+++ b/src/hci/socket.rs
@@ -1,5 +1,6 @@
-//! BlueZ socket layer. Interacts with the BlueZ driver over socket AF_BLUETOOTH.use core::pin::Pin;
+//! BlueZ socket layer. Interacts with the BlueZ driver over socket AF_BLUETOOTH.
 
+use core::pin::Pin;
 use std::os::unix::{
     io::{AsRawFd, FromRawFd, RawFd},
     net::UnixStream,


### PR DESCRIPTION
The previous commit has accidentally removed (or rather moved to a comment) an import to `core::pin::Pin`. This PR puts it back, allowing builds to be successful once more.